### PR TITLE
chore: README, testdekning og robusthet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,64 @@
-# Pensjon Infotrygd TP MQ Adapter
+# pensjon-infotrygd-tp-mq-adapter
 
-Applikasjonen mottar meldinger på kø fra Infotrygd og gjør REST-kall til TP for å hente informasjon. Meldingene fra
-Infotrygd kommer på CopyBook-format med EBCDIC karaketersett.
+Mottar meldinger fra Infotrygd på IBM MQ, slår opp tjenestepensjonsytelser i TP-registeret og sender svar tilbake. Meldingene fra Infotrygd kommer på CopyBook-format med EBCDIC-tegnsett.
+
+## Arkitektur
+
+```mermaid
+flowchart LR
+    IT[Infotrygd\nmainframe] -->|IBM MQ\nK278M402 CopyBook| A[pensjon-infotrygd-\ntp-mq-adapter]
+    A -->|REST GET /api/tjenestepensjon/\nAzure AD client_credentials| TP[tp-registeret]
+    TP -->|ytelser| A
+    A -->|IBM MQ\nK278M402 CopyBook| IT
+```
+
+## Meldingsformat
+
+Applikasjonen bruker CopyBook-meldingsformatet `K278M402`.
+
+### Input (fra Infotrygd)
+
+| Felt | Type | Beskrivelse |
+|------|------|-------------|
+| `iFnr` | `9(11)` | Fødselsnummer det søkes på |
+| `iFom` | `S9(6) Comp-3` | Fra-dato for periode (valgfri) |
+| `iTom` | `S9(6) Comp-3` | Til-dato for periode (valgfri) |
+
+### Output (til Infotrygd)
+
+| Felt | Type | Beskrivelse |
+|------|------|-------------|
+| `oTPnr` | `S9(4) Comp-3` | Tjenestepensjonsnummer (ordningsnummer) |
+| `oTPart` | `9` | Ytelsestype: 1=Alder, 2=Uføre, 3=Gjenlevende, 5=Barn, 6=AFP |
+| `oFom` | `S9(6) Comp-3` | Dato ytelse ble iverksatt fra |
+| `oTom` | `S9(6) Comp-3` | Dato ytelse ble iverksatt til (null = pågående) |
+
+## Feilhåndtering
+
+| `alvorlighetsgrad` | `beskMelding` | Årsak |
+|--------------------|---------------|-------|
+| `0` | `INGEN FEIL PÅ RETURNERT MELDING` | Ytelser funnet og returnert |
+| `4` | `INGEN DATA FUNNET` | Ingen ytelser for angitt fnr/periode |
+| `8` | `SYSTEMFEIL` | Uventet feil ved oppslag mot TP-registeret |
+
+## Tech stack
+
+- **Språk:** Kotlin · Java 21
+- **Rammeverk:** Spring Boot 3
+- **Meldingskø:** IBM MQ (JMS)
+- **Auth:** Azure AD client_credentials
+- **Plattform:** Nais (FSS) · Vault · OpenTelemetry → Elastic APM
+
+## Bygg og test
+
+```shell
+./mvnw clean verify
+```
 
 ## Kjøre applikasjonen lokalt mot testmiljø
 
 > [!NOTE]
-Dette krever tilgang til Nav sine testmiljø via _naisdevice_.
+> Dette krever tilgang til Nav sine testmiljø via _naisdevice_.
 
 Opprett en `.env-fil` med hemmeligheter og konfigurasjon for miljøet ved å
 kjøre følgende kommando.
@@ -29,5 +81,10 @@ legger du til stien til `.env-filen` som ble opprettet. Om
 `Modify options` og velge `Environment variables` fra menyen som vises.
 
 > [!NOTE]
-Instansene som allerede kjører i miljøet vil fortsette å lese meldinger fra kø. For å være sikker på at du mottar
-> meldinger lokalt må du kjøre ned instansene i miljøet du vil kjøre mot
+> Instansene som allerede kjører i miljøet vil fortsette å lese meldinger fra kø. For å være sikker på at du mottar
+> meldinger lokalt må du kjøre ned instansene i miljøet du vil kjøre mot.
+
+## Kontakt
+
+- **Team:** Pensjonsamhandling
+- **Slack:** [#pensjon_samhandling](https://nav-it.slack.com/archives/pensjon_samhandling)

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.ibm.mq</groupId>
             <artifactId>mq-jms-spring-boot-starter</artifactId>
             <version>3.5.5</version>

--- a/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/Application.kt
+++ b/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/Application.kt
@@ -8,6 +8,11 @@ import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.web.client.RestClient
 
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.EnableRetry
+import org.springframework.retry.annotation.Retryable
+
+@EnableRetry
 @SpringBootApplication
 class Application {
     @Bean

--- a/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/JmsConfig.kt
+++ b/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/JmsConfig.kt
@@ -1,0 +1,25 @@
+package no.nav.pensjon.infotrygd.tp.mq.adapter
+
+import jakarta.jms.ConnectionFactory
+import org.slf4j.LoggerFactory.getLogger
+import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory
+import org.springframework.util.backoff.FixedBackOff
+
+@Configuration
+class JmsConfig {
+    private val logger = getLogger(javaClass)
+
+    @Bean
+    fun jmsListenerContainerFactory(
+        configurer: DefaultJmsListenerContainerFactoryConfigurer,
+        connectionFactory: ConnectionFactory,
+    ): DefaultJmsListenerContainerFactory = DefaultJmsListenerContainerFactory().apply {
+        configurer.configure(this, connectionFactory)
+        setConcurrency("1-5")
+        setErrorHandler { e -> logger.error("Feil ved behandling av JMS-melding", e) }
+        setBackOff(FixedBackOff(1000L, 3))
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/infotrygd/InfotrygdService.kt
@@ -28,7 +28,7 @@ class InfotrygdService(
 ) {
     private val logger = getLogger(javaClass)
 
-    @JmsListener(destination = "\${infotrygd.k278m402.queue}", concurrency = "1-5")
+    @JmsListener(destination = "\${infotrygd.k278m402.queue}")
     fun hentTjenestepensjonsYtelsesListe(
         bytes: ByteArray,
         message: Message,

--- a/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/tp/TjenestepensjonException.kt
+++ b/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/tp/TjenestepensjonException.kt
@@ -1,0 +1,3 @@
+package no.nav.pensjon.infotrygd.tp.mq.adapter.tp
+
+class TjenestepensjonException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/tp/TjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/tp/TjenestepensjonService.kt
@@ -3,6 +3,8 @@ package no.nav.pensjon.infotrygd.tp.mq.adapter.tp
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.pensjon.infotrygd.tp.mq.adapter.utils.isOverlapping
 import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
@@ -12,6 +14,7 @@ import java.time.LocalDate
 class TjenestepensjonService(
     private val tpRestClient: RestClient,
 ) {
+    @Retryable(maxAttempts = 3, backoff = Backoff(delay = 500))
     fun hentTjenestepensjon(fnr: String): List<ForholdModel> {
         val tjenestepensjon: TjenestepensjonModel = tpRestClient.get()
             .uri("/api/tjenestepensjon/")
@@ -19,7 +22,7 @@ class TjenestepensjonService(
             .header("fnr", fnr)
             .retrieve()
             .body()
-            ?: throw RuntimeException("Fikk tomt svar fra tp-registeret")
+            ?: throw TjenestepensjonException("Fikk tomt svar fra tp-registeret")
 
         return tjenestepensjon.forhold
     }

--- a/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/azuread/AzureAdClientCredentialsServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/azuread/AzureAdClientCredentialsServiceTest.kt
@@ -1,0 +1,117 @@
+package no.nav.pensjon.infotrygd.tp.mq.adapter.azuread
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private const val TOKEN_ENDPOINT = "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token"
+private const val CLIENT_ID = "test-client-id"
+private const val CLIENT_SECRET = "test-client-secret"
+private const val SCOPE = "api://test/.default"
+private val SCOPES = setOf(SCOPE)
+
+private val TOKEN_RESPONSE = """
+    {
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "access_token": "eyJtest.token.value"
+    }
+""".trimIndent()
+
+class AzureAdClientCredentialsServiceTest {
+
+    private lateinit var server: MockRestServiceServer
+    private lateinit var service: AzureAdClientCredentialsService
+
+    @BeforeEach
+    fun setUp() {
+        val builder = RestClient.builder()
+        server = MockRestServiceServer.bindTo(builder).build()
+        service = AzureAdClientCredentialsService(
+            azureRestClient = builder.build(),
+            clientId = CLIENT_ID,
+            clientSecret = CLIENT_SECRET,
+            tokenEndpoint = TOKEN_ENDPOINT,
+        )
+    }
+
+    @Test
+    fun `henter access token`() {
+        server.expect(requestTo(TOKEN_ENDPOINT))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(withSuccess(TOKEN_RESPONSE, MediaType.APPLICATION_JSON))
+
+        val token = service.accessToken(SCOPES)
+
+        assertEquals("eyJtest.token.value", token)
+        server.verify()
+    }
+
+    @Test
+    fun `token caches og hentes ikke på nytt ved andre kall`() {
+        server.expect(requestTo(TOKEN_ENDPOINT))
+            .andRespond(withSuccess(TOKEN_RESPONSE, MediaType.APPLICATION_JSON))
+
+        val token1 = service.accessToken(SCOPES)
+        val token2 = service.accessToken(SCOPES)
+
+        assertEquals(token1, token2)
+        server.verify() // verifiserer at det kun ble gjort ett kall
+    }
+
+    @Test
+    fun `TokenResponse isValid er true for nylig hentet token`() {
+        val response = ClientCredentialsTokenResponse(
+            tokenType = "Bearer",
+            expiresIn = 3600,
+            accessToken = "eyJtest"
+        )
+        assertTrue(response.isValid)
+    }
+
+    @Test
+    fun `kaster ClientCredentialsException ved 404`() {
+        server.expect(requestTo(TOKEN_ENDPOINT))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND))
+
+        assertFailsWith<ClientCredentialsException> {
+            service.accessToken(SCOPES)
+        }
+    }
+
+    @Test
+    fun `kaster ClientCredentialsException ved 500`() {
+        server.expect(requestTo(TOKEN_ENDPOINT))
+            .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
+
+        assertFailsWith<ClientCredentialsException> {
+            service.accessToken(SCOPES)
+        }
+    }
+
+    @Test
+    fun `fetch returnerer token med korrekte felter`() {
+        server.expect(requestTo(TOKEN_ENDPOINT))
+            .andRespond(withSuccess(TOKEN_RESPONSE, MediaType.APPLICATION_JSON))
+
+        val response = service.fetch(SCOPES)
+
+        assertNotNull(response)
+        assertEquals("Bearer", response.tokenType)
+        assertEquals(3600L, response.expiresIn)
+        assertEquals("eyJtest.token.value", response.accessToken)
+        assertTrue(response.isValid)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/infotrygd/InfotrygdServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/infotrygd/InfotrygdServiceTest.kt
@@ -1,0 +1,114 @@
+package no.nav.pensjon.infotrygd.tp.mq.adapter.infotrygd
+
+import jakarta.jms.BytesMessage
+import jakarta.jms.Destination
+import jakarta.jms.Message
+import jakarta.jms.Session
+import no.nav.pensjon.infotrygd.tp.mq.adapter.infotrygd.InfotrygdMessage.Companion.deserialize
+import no.nav.pensjon.infotrygd.tp.mq.adapter.infotrygd.InfotrygdMessage.Companion.serialize
+import no.nav.pensjon.infotrygd.tp.mq.adapter.tp.TjenestepensjonService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.jms.core.JmsTemplate
+import org.springframework.jms.core.MessageCreator
+import java.nio.charset.Charset
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class InfotrygdServiceTest {
+
+    @Mock private lateinit var jmsTemplate: JmsTemplate
+    @Mock private lateinit var tjenestepensjonService: TjenestepensjonService
+    @Mock private lateinit var message: Message
+    @Mock private lateinit var replyTo: Destination
+
+    private lateinit var service: InfotrygdService
+    private val charset = Charset.forName("ibm277")
+    private val capturedResponseBytes = mutableListOf<ByteArray>()
+
+    @BeforeEach
+    fun setUp() {
+        service = InfotrygdService(jmsTemplate, tjenestepensjonService, "TEST.QUEUE")
+        capturedResponseBytes.clear()
+    }
+
+    @Test
+    fun `ingen ytelser fra TP gir alvorlighetsgrad 4`() {
+        stubMessage()
+        stubJmsTemplateSend()
+        `when`(tjenestepensjonService.hentTjenestepensjon("12345678901")).thenReturn(emptyList())
+
+        service.hentTjenestepensjonsYtelsesListe(lagRequestBytes("12345678901"), message)
+
+        val svar = lesRespons()
+        assertEquals(4, svar.alvorlighetsgrad)
+        assertEquals("INGEN DATA FUNNET", svar.beskMelding)
+        assertEquals(0, svar.antall)
+    }
+
+    @Test
+    fun `exception fra TP gir alvorlighetsgrad 8`() {
+        stubMessage()
+        stubJmsTemplateSend()
+        `when`(tjenestepensjonService.hentTjenestepensjon("12345678901"))
+            .thenThrow(RuntimeException("TP er nede"))
+
+        service.hentTjenestepensjonsYtelsesListe(lagRequestBytes("12345678901"), message)
+
+        val svar = lesRespons()
+        assertEquals(8, svar.alvorlighetsgrad)
+        assertEquals("SYSTEMFEIL", svar.beskMelding)
+    }
+
+    // 🔴 Rød sone — skriv disse selv:
+    // - asTpArt-mapping: ALDER→1, UFORE→2, GJENLEVENDE→3, BARN→5, AFP→6, ukjent→null
+    // - datofiltrering: kun iFom, begge satt, ingen datoer
+    // - output-records er sortert stigende på oFom
+    // Bruk [lagRequestBytes] og [lesRespons] som utgangspunkt.
+
+    private fun stubMessage() {
+        `when`(message.getStringProperty(any())).thenReturn(charset.name())
+        `when`(message.jmsReplyTo).thenReturn(replyTo)
+        `when`(message.jmsMessageID).thenReturn("ID:test-message-id")
+        `when`(message.jmsCorrelationID).thenReturn("ID:test-correlation-id")
+    }
+
+    private fun stubJmsTemplateSend() {
+        doAnswer { invocation ->
+            val session = mock(Session::class.java)
+            val bytesMessage = mock(BytesMessage::class.java)
+            `when`(session.createBytesMessage()).thenReturn(bytesMessage)
+            doAnswer { args -> capturedResponseBytes.add(args.getArgument(0)); null }
+                .`when`(bytesMessage).writeBytes(any())
+            invocation.getArgument<MessageCreator>(1).createMessage(session)
+            null
+        }.`when`(jmsTemplate).send(any(Destination::class.java), any(MessageCreator::class.java))
+    }
+
+    private fun lagRequestBytes(fnr: String, iFom: LocalDate? = null, iTom: LocalDate? = null): ByteArray =
+        serialize(
+            InfotrygdMessage(
+                kodeAksjon = null, kilde = "IT00", brukerId = "K278CB1X", lengde = 313,
+                dato = "20240916", klokke = "131515", systemId = null, kodeMelding = null,
+                alvorlighetsgrad = 0, beskMelding = null, sqlKode = null, sqlState = null,
+                sqlMelding = null, mqCompletionCode = null, mqReasonCode = null,
+                progId = null, sectionNavn = null, copyId = "K278M402", antall = 1,
+                outputRecords = listOf(InfotrygdMessage.K278M402(fnr, iFom, iTom, null, null, null, null)),
+            ),
+            charset,
+        )
+
+    private fun lesRespons(): InfotrygdMessage {
+        assertTrue(capturedResponseBytes.isNotEmpty(), "Ingen respons sendt til Infotrygd")
+        return deserialize(capturedResponseBytes.last(), charset)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/tp/TjenestepensjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/tp/TjenestepensjonServiceTest.kt
@@ -1,0 +1,124 @@
+package no.nav.pensjon.infotrygd.tp.mq.adapter.tp
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TjenestepensjonServiceTest {
+
+    private lateinit var server: MockRestServiceServer
+    private lateinit var service: TjenestepensjonService
+
+    @BeforeEach
+    fun setUp() {
+        val builder = RestClient.builder()
+        server = MockRestServiceServer.bindTo(builder).build()
+        service = TjenestepensjonService(builder.build())
+    }
+
+    // --- YtelseModel datofiltrering ---
+
+    @Test
+    fun `ytelse uten TOM er alltid gyldig etter FOM`() {
+        val ytelse = TjenestepensjonService.YtelseModel("ALDER", LocalDate.of(2020, 1, 1), null)
+        assertTrue(ytelse.isIverksattDatesOverlapping(LocalDate.of(2099, 1, 1)))
+    }
+
+    @Test
+    fun `ytelse med TOM etter from er gyldig`() {
+        val ytelse = TjenestepensjonService.YtelseModel("ALDER", LocalDate.of(2020, 1, 1), LocalDate.of(2025, 1, 1))
+        assertTrue(ytelse.isIverksattDatesOverlapping(LocalDate.of(2024, 1, 1)))
+    }
+
+    @Test
+    fun `ytelse med TOM lik from er gyldig`() {
+        val dato = LocalDate.of(2024, 1, 1)
+        val ytelse = TjenestepensjonService.YtelseModel("ALDER", LocalDate.of(2020, 1, 1), dato)
+        assertTrue(ytelse.isIverksattDatesOverlapping(dato))
+    }
+
+    @Test
+    fun `ytelse med TOM før from er ikke gyldig`() {
+        val ytelse = TjenestepensjonService.YtelseModel("ALDER", LocalDate.of(2020, 1, 1), LocalDate.of(2022, 1, 1))
+        assertFalse(ytelse.isIverksattDatesOverlapping(LocalDate.of(2023, 1, 1)))
+    }
+
+    @Test
+    fun `ytelse overlapper med periode fom-tom`() {
+        val ytelse = TjenestepensjonService.YtelseModel("ALDER", LocalDate.of(2020, 1, 1), LocalDate.of(2023, 12, 31))
+        assertTrue(ytelse.isIverksattDatesOverlapping(LocalDate.of(2022, 1, 1), LocalDate.of(2025, 1, 1)))
+    }
+
+    @Test
+    fun `ytelse overlapper ikke med periode fom-tom`() {
+        val ytelse = TjenestepensjonService.YtelseModel("ALDER", LocalDate.of(2020, 1, 1), LocalDate.of(2021, 12, 31))
+        assertFalse(ytelse.isIverksattDatesOverlapping(LocalDate.of(2022, 1, 1), LocalDate.of(2025, 1, 1)))
+    }
+
+    // --- REST-kall ---
+
+    @Test
+    fun `hentTjenestepensjon returnerer tom liste når ingen forhold`() {
+        server.expect(requestTo("/api/tjenestepensjon/"))
+            .andExpect(method(HttpMethod.GET))
+            .andExpect(header("fnr", "12345678901"))
+            .andRespond(withSuccess("""{"forhold":[]}""", MediaType.APPLICATION_JSON))
+
+        val result = service.hentTjenestepensjon("12345678901")
+
+        assertEquals(emptyList(), result)
+        server.verify()
+    }
+
+    @Test
+    fun `hentTjenestepensjon mapper ytelser korrekt`() {
+        val json = """
+            {
+                "forhold": [{
+                    "ordning": "3010",
+                    "ytelser": [{
+                        "type": "ALDER",
+                        "datoYtelseIverksattFom": "2025-01-01",
+                        "datoYtelseIverksattTom": null
+                    }]
+                }]
+            }
+        """.trimIndent()
+
+        server.expect(requestTo("/api/tjenestepensjon/"))
+            .andRespond(withSuccess(json, MediaType.APPLICATION_JSON))
+
+        val result = service.hentTjenestepensjon("12345678901")
+
+        assertEquals(1, result.size)
+        assertEquals("3010", result[0].ordning)
+        assertEquals(1, result[0].ytelser.size)
+        assertEquals("ALDER", result[0].ytelser[0].type)
+        assertEquals(LocalDate.of(2025, 1, 1), result[0].ytelser[0].datoYtelseIverksattFom)
+        assertNull(result[0].ytelser[0].datoYtelseIverksattTom)
+        server.verify()
+    }
+
+    @Test
+    fun `hentTjenestepensjon kaster exception ved tomt svar`() {
+        server.expect(requestTo("/api/tjenestepensjon/"))
+            .andRespond(withSuccess("null", MediaType.APPLICATION_JSON))
+
+        assertFailsWith<RuntimeException> {
+            service.hentTjenestepensjon("12345678901")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/utils/LocalDateUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/infotrygd/tp/mq/adapter/utils/LocalDateUtilTest.kt
@@ -1,0 +1,84 @@
+package no.nav.pensjon.infotrygd.tp.mq.adapter.utils
+
+import java.time.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LocalDateUtilTest {
+
+    @Test
+    fun `begge perioder er åpne - overlapper alltid`() {
+        assertTrue(isOverlapping(null, null, null, null))
+    }
+
+    @Test
+    fun `perioder overlapper i midten`() {
+        assertTrue(isOverlapping(
+            LocalDate.of(2020, 1, 1), LocalDate.of(2020, 6, 30),
+            LocalDate.of(2020, 4, 1), LocalDate.of(2020, 12, 31),
+        ))
+    }
+
+    @Test
+    fun `perioder overlapper ikke - A slutter før B starter`() {
+        assertFalse(isOverlapping(
+            LocalDate.of(2020, 1, 1), LocalDate.of(2020, 3, 31),
+            LocalDate.of(2020, 4, 1), LocalDate.of(2020, 12, 31),
+        ))
+    }
+
+    @Test
+    fun `perioder overlapper ikke - B slutter før A starter`() {
+        assertFalse(isOverlapping(
+            LocalDate.of(2021, 1, 1), LocalDate.of(2021, 12, 31),
+            LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31),
+        ))
+    }
+
+    @Test
+    fun `perioder er identiske`() {
+        val date = LocalDate.of(2020, 6, 1)
+        assertTrue(isOverlapping(date, date, date, date))
+    }
+
+    @Test
+    fun `A slutter samme dag som B starter - overlapper`() {
+        assertTrue(isOverlapping(
+            LocalDate.of(2020, 1, 1), LocalDate.of(2020, 6, 1),
+            LocalDate.of(2020, 6, 1), LocalDate.of(2020, 12, 31),
+        ))
+    }
+
+    @Test
+    fun `åpen slutt på A - overlapper alltid med fremtidig B`() {
+        assertTrue(isOverlapping(
+            LocalDate.of(2020, 1, 1), null,
+            LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31),
+        ))
+    }
+
+    @Test
+    fun `åpen start på B - overlapper alltid`() {
+        assertTrue(isOverlapping(
+            LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31),
+            null, LocalDate.of(2025, 12, 31),
+        ))
+    }
+
+    @Test
+    fun `åpen slutt på B - overlapper hvis A starter etter B sin start`() {
+        assertTrue(isOverlapping(
+            LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31),
+            LocalDate.of(2019, 1, 1), null,
+        ))
+    }
+
+    @Test
+    fun `åpen start på A og åpen slutt på B - overlapper alltid`() {
+        assertTrue(isOverlapping(
+            null, LocalDate.of(2025, 1, 1),
+            LocalDate.of(2020, 1, 1), null,
+        ))
+    }
+}


### PR DESCRIPTION
## Hva er gjort

### README
- Lagt til arkitekturdiagram (Mermaid), meldingsformat (K278M402), feilhåndtering, tech stack og kontaktinfo
- Samme struktur som `sam` og `sporingslogg`

### Testdekning (34 tester, alle grønne)
- `LocalDateUtilTest` — `isOverlapping` alle hjørnetilfeller
- `TjenestepensjonServiceTest` — `YtelseModel` datofiltrering + REST-kall
- `AzureAdClientCredentialsServiceTest` — token-cache, 404/500-feilhåndtering
- `InfotrygdServiceTest` — ingen data → alvorlighetsgrad 4, systemfeil → alvorlighetsgrad 8

> 🔴 **Rød sone:** `asTpArt`-mapping og datofiltrering gjenstår — hjelpemetodene `lagRequestBytes` og `lesRespons` er klare til bruk.

### Robusthet
- `JmsConfig`: `FixedBackOff(1s, 3 forsøk)` + `ErrorHandler` — hindrer poison-message-loop
- `@Retryable(3 forsøk, 500ms)` på `hentTjenestepensjon()` — tåler transient nettverksfeil mot TP
- `TjenestepensjonException` erstatter generisk `RuntimeException`