### PR TITLE
chore: rydd opp workflows — 4 klare steg + sandbox

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -1,0 +1,84 @@
+name: Build and Deploy Sandbox
+
+on:
+  push:
+    branches: [sandbox]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: maven
+      - name: Build and test
+        run: ./mvnw verify --no-transfer-progress
+      - name: Publish test report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: Maven Tests
+          path: '**/target/surefire-reports/TEST-*.xml'
+          reporter: java-junit
+      - name: Upload JAR
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-jar
+          path: target/adapter*.jar
+          retention-days: 1
+
+  build-image:
+    name: Build Image (sandbox)
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set version
+        id: version
+        run: echo "version=$(git rev-parse --short=12 HEAD)" >> $GITHUB_OUTPUT
+      - name: Download JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+          path: target/
+      - name: Build and push image
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
+        with:
+          team: pensjonsamhandling
+          tag: ${{ github.event.repository.name }}-sandbox
+          image_suffix: sandbox
+
+  deploy-sandbox:
+    name: Deploy Sandbox (${{ matrix.env }})
+    needs: build-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        env: [q1, q2]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          IMAGE: ${{ needs.build-image.outputs.image }}
+          RESOURCE: .nais/nais.yaml
+          CLUSTER: dev-fss
+          VAR: version=${{ needs.build-image.outputs.version }}
+          VARS: .nais/vars-dev-${{ matrix.env }}.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,101 +1,115 @@
-name: "Build and deploy"
+name: Build and Deploy
 
 on:
-  push
-
-env:
-  IMAGE_BASE: ghcr.io/${{ github.repository }}
+  push:
+  workflow_dispatch:
 
 jobs:
-  build:
-    permissions:
-      contents: "read"
-      checks: "write"
-      id-token: "write"
-      packages: "write"
+  build-and-test:
+    name: Build and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      image: "${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:${{ env.VERSION }}"
-      image-digest: "${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter@${{ steps.build_push.outputs.digest }}"
-
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: maven
+      - name: Build and test
+        run: ./mvnw verify --no-transfer-progress
+      - name: Publish test report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: Maven Tests
+          path: '**/target/surefire-reports/TEST-*.xml'
+          reporter: java-junit
+      - name: Upload JAR
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-jar
+          path: target/adapter*.jar
+          retention-days: 1
 
+  build-image:
+    name: Build Image
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      image: "${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:${{ steps.version.outputs.version }}"
+      image-digest: "${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter@${{ steps.build_push.outputs.digest }}"
+    steps:
+      - uses: actions/checkout@v7
       - name: Set version
         id: version
-        shell: bash
         run: |
           TIME=$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M)
           COMMIT=$(git rev-parse --short=12 HEAD)
-          export VERSION="$TIME-$COMMIT"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - uses: actions/setup-java@v5
+          echo "version=$TIME-$COMMIT" >> $GITHUB_OUTPUT
+      - name: Download JAR
+        uses: actions/download-artifact@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
+          name: app-jar
+          path: target/
       - uses: docker/setup-buildx-action@v4
-
-      - name: Build
-        shell: bash
-        run: |
-          mvn -Drevision="${VERSION}" package
-        env:
-          TZ: "Europe/Oslo"
-
-      - name: Upload surefire reports on failure
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: surefire-reports
-          path: ${{ github.workspace }}/**/target/surefire-reports/*
-          retention-days: 5
-
-      - name: Upload HotSpot Fatal Error logs on failure
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: hotspot-fatal-error-logs
-          path: ${{ github.workspace }}/**/hs_err_pid*.log
-          retention-days: 5
-
       - name: NAIS login
-        if: github.ref == 'refs/heads/main'
         uses: nais/login@v0
         id: login
         with:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           team: pensjonsamhandling
-
-      - name: "Build and publish Docker image"
-        if: github.ref == 'refs/heads/main'
-        id: build_push
+      - name: Build and push image
         uses: docker/build-push-action@v7
+        id: build_push
         with:
           context: .
-          file: Dockerfile
-          tags: "${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:${{ env.VERSION }},${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:main"
           push: true
-          cache-from: |
-            "type=registry,ref=${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:main"
+          tags: |
+            ${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:${{ steps.version.outputs.version }}
+            ${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:main
+          cache-from: type=registry,ref=${{ steps.login.outputs.registry }}/${{ github.repository }}/pensjon-infotrygd-tp-mq-adapter:main
           cache-to: type=inline
 
-  attest-sign:
-    if: github.ref == 'refs/heads/main'
+  deploy-dev:
+    name: Deploy Dev (${{ matrix.env }})
+    needs: build-image
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    needs: [build]
-    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        env: [q0, q1, q2]
     steps:
       - uses: actions/checkout@v7
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          IMAGE: ${{ needs.build-image.outputs.image }}
+          RESOURCE: .nais/nais.yaml
+          CLUSTER: dev-fss
+          VAR: version=${{ needs.build-image.outputs.version }}
+          VARS: .nais/vars-dev-${{ matrix.env }}.yaml
 
+  sign-and-deploy-prod:
+    name: Sign and Deploy Prod
+    needs: build-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
       - name: NAIS login
         uses: nais/login@v0
         id: login
@@ -103,60 +117,22 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           team: pensjonsamhandling
-
-      - name: 'Generate SBOM'
+      - name: Generate SBOM
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          scan-type: 'image'
-          format: 'cyclonedx'
-          output: 'trivy-results.cyclonedx'
-          image-ref: "${{ needs.build.outputs.image-digest }}"
-
+          scan-type: image
+          format: cyclonedx
+          output: trivy-results.cyclonedx
+          image-ref: ${{ needs.build-image.outputs.image-digest }}
       - name: Attest and sign image
-        id: attest-sign
         uses: nais/attest-sign@v2
         with:
-          image_ref: "${{ needs.build.outputs.image-digest }}"
-          sbom: "trivy-results.cyclonedx"
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      id-token: write
-    needs: [build]
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v7
+          image_ref: ${{ needs.build-image.outputs.image-digest }}
+          sbom: trivy-results.cyclonedx
       - uses: nais/deploy/actions/deploy@v2
         env:
-          IMAGE: "${{ needs.build.outputs.image }}"
+          IMAGE: ${{ needs.build-image.outputs.image }}
           RESOURCE: .nais/nais.yaml
-          CLUSTER: 'prod-fss'
-          VAR: "version=${{ needs.build.outputs.version }}"
-          VARS: '.nais/vars-prod.yaml'
-
-  deployQ:
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      id-token: write
-    needs: [build]
-    runs-on: 'ubuntu-latest'
-
-    strategy:
-      matrix:
-        include:
-          - env: q0
-          - env: q1
-          - env: q2
-
-    steps:
-      - uses: actions/checkout@v7
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          IMAGE: "${{ needs.build.outputs.image }}"
-          RESOURCE: .nais/nais.yaml
-          CLUSTER: 'dev-fss'
-          VAR: "version=${{ needs.build.outputs.version }}"
-          VARS: '.nais/vars-dev-${{matrix.env}}.yaml'
+          CLUSTER: prod-fss
+          VAR: version=${{ needs.build-image.outputs.version }}
+          VARS: .nais/vars-prod.yaml


### PR DESCRIPTION
## Endringer

### `build.yml` — refaktorert til 4 tydelige jobs

```
build-and-test  →  build-image  →  deploy-dev (q0/q1/q2)
                               ↘  sign-and-deploy-prod
```

| Job | Hva |
|-----|-----|
| `build-and-test` | mvn verify, testrappport (dorny), last opp JAR |
| `build-image` | last ned JAR, sett versjon, docker build+push |
| `deploy-dev` | matrix q0/q1/q2 → dev-fss |
| `sign-and-deploy-prod` | SBOM + attest+sign + deploy → prod-fss |

### `build-sandbox.yml` — ny workflow

- Trigger: push til `sandbox`-branch + `workflow_dispatch`
- Samme build-and-test som main
- Docker image med `sandbox`-suffix via `nais/docker-build-push@v0`
- Deploy til q1 og q2 (ikke q0)