### PR TITLE
fix: oppgrader Tomcat 10.1.46 → 10.1.55 (CVE-fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
     <properties>
         <java.version>21</java.version>
         <kotlin.version>2.4.10</kotlin.version>
+        <!-- Override Spring Boot sin bundlede Tomcat for å fikse CVE-er i 10.1.46 -->
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Problem
6 CRITICAL + 2 HIGH CVE-er i `tomcat-embed-core@10.1.46` rapportert fra NAIS console.

## Fix
Én linje i `pom.xml` — Spring Boot BOM-property som overskriver Tomcat-versjonen:
```xml
<tomcat.version>10.1.55</tomcat.version>
```
Ingen Spring Boot major-upgrade nødvendig.

## Gjenstår
- `bcprov-jdk18on@1.80` (fra IBM MQ) — ingen nyere versjon tilgjengelig på Maven Central, avventer IBM MQ-oppdatering (#56)
- `golang.org/x/net` — NAIS-sidecar, ikke vår kode

## Test
34/34 tester grønne ✅